### PR TITLE
Fix provider error message

### DIFF
--- a/src/components/context/useFormContext.ts
+++ b/src/components/context/useFormContext.ts
@@ -21,7 +21,9 @@ interface FormControlState {
 export const useFormContext = (): FormContextType => {
   const context = useContext(FormContext);
   if (!context) {
-    throw new Error("useFormContext must be used within a FormProvider");
+    throw new Error(
+      "useFormContext must be used within a FormContext.Provider"
+    );
   }
   return context;
 };


### PR DESCRIPTION
## Summary
- adjust error message in `useFormContext` to mention the correct provider

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847c37c8b6083308b845b270ae5aa1d